### PR TITLE
Remove styles for table element

### DIFF
--- a/src/main/resources/META-INF/resources/css/GTC.css
+++ b/src/main/resources/META-INF/resources/css/GTC.css
@@ -88,10 +88,6 @@ pre {
     font-size: 14px;
 }
 
-table {
-    margin-top: 15px;
-}
-
 a.img-help {
     font-size: 19px;
 }
@@ -878,7 +874,7 @@ html {
     overflow: hidden;
     top: 30px;
     right:80px;
-}*/            
+}*/
 
 .userGuide:hover > .icon_userGuide {
     margin-top: -49px;


### PR DESCRIPTION
table要素に対してmargin-top: 15pxが指定されていたために、トップページのGoogle検索フォームがずれて表示されていた。
※この変更は、すべてのtable要素に影響するので、上部余白が必要なtableについては別途CSSを当てる必要が出てくるかもしれません。